### PR TITLE
Update climate prereqs

### DIFF
--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -58,7 +58,7 @@ To ensure clarity and set proper expectations, let’s revisit what you can expe
     
 - For those with less of a programming background, it is crucial to study the material well in advance. We recommend beginning as early as possible to ensure you have ample time to cover the content. Practice every day and you'll be in great shape before the course begins.
     
-- You won't need to install Python on your computer for the Python pre-course. All you need to do is click the rocket-shaped button in the upper right corner of the lessons ** CHECK THIS TOO I DIDNT NEED TO SIGN IN and sign in using your Github account**. 
+- You won't need to install Python on your computer for the Python pre-course. All you need to do is click the rocket-shaped button in the upper right corner of the lessons and sign in using your Github account if needed. 
 
 - The section [“How to use this book”](https://foundations.projectpythia.org/preamble/how-to-use.html#how-to-use-this-book) provides you with alternative options to run the Python code should you need to.
 

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -18,7 +18,7 @@ Welcome to [Climatematch Academy](https://academy.climatematch.io/about/mission)
 ## Programming
 
 
-We expect students to be familiar with fundamental Python and data storage concepts (variables, lists, dictionaries, data formats) as well as some key Python libraries (NumPy, matplotlib, cartopy, datetime, pandas, XArray).  If these feel unfamiliar, we **highly recommend** you take our refresher **Python pre-course**. It is a selection of Project Pythia tutorials (outlined below) that you will work through asynchronously *before* the course begins. 
+We expect students to be familiar with fundamental Python and data storage concepts (variables, lists, dictionaries, data formats) as well as some key Python libraries (NumPy, matplotlib, cartopy, datetime, pandas, XArray).  If these feel unfamiliar, we **highly recommend** you take our refresher **Python pre-course**. It is a selection of Project Pythia tutorials (outlined below) that you will work through asynchronously *before* the course begins at your own pace.
 
 What is Project Pythia? Check out the fantastic [~5min video](https://bit.ly/42P799Y) that Julia Kent prepared for you as an intro to this fabulous material.
 
@@ -48,19 +48,15 @@ Below are the lessons you need to review. **To get started with a tutorial just 
 | [Data Formats](https://foundations.projectpythia.org/core/data-formats.html) | 50 |
 | Optional (will be covered in the first day of course materials): [Xarray](https://foundations.projectpythia.org/core/xarray.html) | 150 |
 
-**You will work through the material at your own pace, getting asynchronous help on **Discord as needed during July 12-14. NEED TO CONFIRM THIS** 
-
 To ensure clarity and set proper expectations, let’s revisit what you can expect from the **Python pre-course** and what you should not expect.
 
 ### What You Can Expect from the Python Pre-course
 
-- Asynchronous Support via Discord: ** CHECK THIS Throughout the duration of the precourse, (July 12-14)**, our team will provide support through the Discord platform. You will have the opportunity to ask questions and seek assistance via chat. Please note that we will not be conducting any video calls or virtual classes during the Python pre-course.
-
-- Self-Study Approach: The precourse is not designed as a traditional course with lectures and guided lessons. Instead, we have curated a collection of comprehensive learning materials for you to study independently. These materials are accessible through the links provided. It is essential that you dedicate sufficient time and effort to self-study the content at your own pace through the links provided above.
+- Self-Study Approach: The precourse is *not* designed as a traditional course with lectures and guided lessons. Instead, we have curated a collection of comprehensive learning materials for you to study independently.  It is essential that you dedicate sufficient time and effort to self-study the content at your own pace through the links provided above.
     
-- Prior Programming Experience Advantage: If you have prior experience in programming, you may find this pre-course relatively easier to grasp. 
+- Prior Programming Experience Advantage: If you have prior experience in programming, you may find this pre-course relatively easy to grasp. 
     
- - For those without any previous programming background, it is crucial to start studying the material well in advance. We recommend beginning as early as possible to ensure you have ample time to cover the content. Practice every day and you'll be in great shape before the course begins.
+- For those with less of a programming background, it is crucial to study the material well in advance. We recommend beginning as early as possible to ensure you have ample time to cover the content. Practice every day and you'll be in great shape before the course begins.
     
 - You won't need to install Python on your computer for the Python pre-course. All you need to do is click the rocket-shaped button in the upper right corner of the lessons ** CHECK THIS TOO I DIDNT NEED TO SIGN IN and sign in using your Github account**. 
 
@@ -71,7 +67,7 @@ To ensure clarity and set proper expectations, let’s revisit what you can expe
 
 ### What You Should Not Expect from the Python Pre-course
 
-- Guided Instruction: Please be aware that the Python pre-course does not include virtual online classes or guided instruction. While our team will be available for support via ** CHECK Discord chat during July 12-14**, it is on you to study the material independently and seek clarification as needed.
+- Guided Instruction: Please be aware that the Python pre-course does not include virtual online classes or guided instruction.  It is on you to study the material independently and seek clarification as needed from existing online resources.
 
 - Traditional Classroom Environment: Unlike traditional courses where you attend classes and follow a set schedule, the pre-course relies on your self-motivation and discipline to study the provided materials. There will not be any fixed class times or mandatory attendance.
 
@@ -80,16 +76,10 @@ To ensure clarity and set proper expectations, let’s revisit what you can expe
     
 ## Math 
 
-  
-
 Climatematch Academy relies on linear algebra, probability, basic statistics, and calculus (derivatives, integrals, and ordinary differential equations -ODEs).
-
-  
 
 ### Algebra
 If you need a refresher on basic, pre-calculus algebra check the videos in this [Algebra course](https://bit.ly/3Pnq5cP) from Khan Academy. You will particularly need to know your way around [functions](https://bit.ly/43H5mox) (unit 8 of the course) and their representations, including graphics, because they are the way to express relationships between variables and they are the basic elements you work with in Calculus. 
-
-  
 
 ### Linear algebra
 You will need a good grasp of the basics of linear algebra to follow along, as linear algebra is crucial for almost anything quantitative involving more than one number at a time. It will also help you visualize and understand the way data are organized and manipulated, particularly in computational environments. You need to have a basic understanding of vectors and matrices, and how to perform operations with them. We recommend watching the videos in these units about [vectors](https://bit.ly/3NcM2IK) and [matrices](https://bit.ly/3CDXurX) from Khan Academy. That should be enough to prepare you for CMA. 
@@ -119,7 +109,7 @@ Finally, basic calculus is crucial; you should know what integrals and derivativ
   
 
 ### Physics
-Climate processes are governed by the laws of physics which is why you will need a general understanding of basic physics concepts such as: Newton’s laws of motion, forms of energy, conservation of energy, circular motion (Earth’s rotation and Coriolis force), waves, electromagnetic spectrum, optics, heat, and thermodynamics, etc.
+Climate processes are governed by the laws of physics which is why you will need a general understanding of physics concepts such as: Newton’s laws of motion, forms of energy, conservation of energy, circular motion (Earth’s rotation and Coriolis force), waves, electromagnetic spectrum, optics, heat, and thermodynamics, etc.
 
 Recommended references include the videos from the [College Physics 1](https://www.khanacademy.org/science/ap-college-physics-1) course from Khan Academy for kinematics, Newton’s laws, dynamics, energy, and mechanical waves), the videos from the [College Physics 2](https://www.khanacademy.org/science/ap-physics-2) course from Khan Academy for Heat and Thermodynamics (unit 2), electromagnetic waves (unit 6), and optics (unit 7), and [Dave Van Domelen](https://stratus.ssec.wisc.edu/courses/gg101/coriolis/coriolis.html)’s, [Encyclopedia Britannica](https://www.britannica.com/science/Coriolis-force) or [Wikipedia](https://en.wikipedia.org/wiki/Coriolis_force) entries on Coriolis force. 
 
@@ -134,7 +124,7 @@ Remember that you don’t need to learn all the details and be able to solve com
   
 
 ### Chemistry
-It would be helpful to have general chemistry knowledge regarding atoms, isotopes, molecules, ions, compounds, bonds, etc. We recommend the [College Chemistry course](https://www.khanacademy.org/science/ap-chemistry-beta) (videos in units 1, 2, and 3) from Khan Academy. There is no need to learn all the details and be able to solve complicated problems, just make sure you understand general concepts. We also recommend [these simulations](https://phet.colorado.edu/en/simulations/filter?subjects=general&levels=university&type=html,prototype) from PHET to help illustrate some concepts.
+It is important to have general chemistry knowledge regarding atoms, isotopes, molecules, ions, compounds, bonds, etc. We recommend the [College Chemistry course](https://www.khanacademy.org/science/ap-chemistry-beta) (videos in units 1, 2, and 3) from Khan Academy. There is no need to learn all the details and be able to solve complicated problems, just make sure you understand general concepts. We also recommend [these simulations](https://phet.colorado.edu/en/simulations/filter?subjects=general&levels=university&type=html,prototype) from PHET to help illustrate some concepts.
 
  > Extra material:
  > 

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -1,6 +1,6 @@
 # Prerequisites and preparatory materials for Computational Tools for Climate Science
 
-Welcome to the [Climatematch Academy](https://academy.climatematch.io/about/mission)! We're really excited to bring this course to such a wide and varied audience. We want to make sure every student is able to follow and enjoy the academy. This means you need to know the basics of programming in Python, math and science core concepts. Below 👇 we provide more details for each.
+Welcome to [Computational Tools for Climate Science](https://academy.climatematch.io/about/mission)! We are very excited to bring this course to such a wide and varied audience. We want to make sure every student is able to follow and enjoy the materials presented during the course. In order to get the most out of the materials we offer, we expect our students to know the basics of programming in Python, as well core concepts in math and science. Below 👇 we provide more details for each.
 
 ## Contents
 
@@ -18,18 +18,23 @@ Welcome to the [Climatematch Academy](https://academy.climatematch.io/about/miss
 ## Programming
 
 
-We expect students to be familiar with the following topics in Python: variables, lists, dictionaries, the numpy, matplotlib, cartopy, datetime, pandas and data formats. Students who are not familiar with some of the topics mentioned before, are required to take the **Python pre-course**, which offers asynchronous support for a selection of tutorials from Project Pythia. 
+We expect students to be familiar with fundamental Python and data storage concepts (variables, lists, dictionaries, data formats) as well as some key Python libraries (numpy, matplotlib, cartopy, datetime, pandas, XArray).  If these feel unfamiliar, we **highly recommend** you take our refresher **Python pre-course**. It is a selection of Project Pythia tutorials (outlined below) that you will work through asynchronously *before* the course begins. 
 
 What is Project Pythia? Check out the fantastic [~5min video](https://bit.ly/42P799Y) that Julia Kent prepared for you as an intro to this fabulous material.
 
-Now, let's sumarize what are the lessons you need to review:
+Below are the lessons you need to review, to get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook to launch the Binder
 
-- [Preamble and Foundational Skills](https://bit.ly/4429kYQ): Overview, Why Python, Quickstart: Zero to Python (under the heading “Getting Started with Python”), JupyterLab (under the heading “Getting Started with Jupyter”), What is Github (under the heading “Getting Started with GitHub”) (~3.5 hours)
-    
-- Core Scientific Python Packages: NumPy, Matplotlib, Cartopy, Datetime, Pandas, Data formats (~6 hours). Xarray will be a part of the course Computational Tools for Climate Science, so you do not need to learn it beforehand.
-    
+- [Preamble and Foundational Skills](https://bit.ly/4429kYQ):
 
-- Here [is a breakdown of times per lesson](https://bit.ly/3CHhjid). The topics highlighted in blue are the only mandatory lessons that we expected you have covered in preparation for the course Computational Tools for Climate Science. 
+| Tutorial and Link | Approximate Time to Complete (minutes) |
+| ----------- | ----------- | ----------- |
+| [Interacting with Jupyter Notebooks in the cloud via Binder](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder)  | 10 |
+| [Why Python?](https://foundations.projectpythia.org/foundations/why-python.html) | 15  |
+| [Quickstart: Zero to Python](https://foundations.projectpythia.org/foundations/quickstart.html) | 90 |
+
+- Why Python? and  Quickstart: Zero to Python (under the heading “Getting Started with Python”) tutorials (~2 hours)
+    
+- Core Scientific Python Packages: all tutorials (~6 hours).
     
 
   

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -26,7 +26,7 @@ Below are the lessons you need to review. **To get started with a tutorial just 
 
 ![Launch Binder](../images/binder.png)
 
-### [Preamble and Foundational Skills](https://bit.ly/4429kYQ) (~3 hours)
+### Preamble and Foundational Skills (~3 hours)
 
 | Tutorial Section and Link | Approximate Time to Complete (minutes) |
 | ----------- | ----------- |
@@ -35,7 +35,7 @@ Below are the lessons you need to review. **To get started with a tutorial just 
 | [Quickstart: Zero to Python](https://foundations.projectpythia.org/foundations/quickstart.html) | 90 |
 | [Jupyterlab](https://foundations.projectpythia.org/foundations/jupyterlab.html) | 50 |
     
-### [Core Scientific Python Packages](https://foundations.projectpythia.org/core/overview.html)(~6 hours)
+### Core Scientific Python Packages (~6 hours)
     
 | Tutorial Section and Link | Approximate Time to Complete (minutes) |
 | ----------- | ----------- |

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -27,7 +27,7 @@ Below are the lessons you need to review, to get started with a tutorial just cl
 - [Preamble and Foundational Skills](https://bit.ly/4429kYQ):
 
 | Tutorial and Link | Approximate Time to Complete (minutes) |
-| ----------- | ----------- | ----------- |
+| ----------- | ----------- |
 | [Interacting with Jupyter Notebooks in the cloud via Binder](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder)  | 10 |
 | [Why Python?](https://foundations.projectpythia.org/foundations/why-python.html) | 15  |
 | [Quickstart: Zero to Python](https://foundations.projectpythia.org/foundations/quickstart.html) | 90 |

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -18,11 +18,11 @@ Welcome to [Climatematch Academy](https://academy.climatematch.io/about/mission)
 ## Programming
 
 
-We expect students to be familiar with fundamental Python and data storage concepts (variables, lists, dictionaries, data formats) as well as some key Python libraries (NumPy, matplotlib, cartopy, datetime, pandas, XArray).  If these feel unfamiliar, we **highly recommend** you take our refresher **Python pre-course**. It is a selection of Project Pythia tutorials (outlined below) that you will work through asynchronously *before* the course begins at your own pace.
+We expect students to be familiar with fundamental Python and data storage concepts (variables, lists, dictionaries, data formats) as well as some key Python libraries (NumPy, matplotlib, cartopy, datetime, pandas, XArray).  If these feel a little unfamiliar, you are coming from another programming language, or you just want to make sure you are up to speed for the course, we **highly recommend** you take our **Python Refresher**. It is a selection of Project Pythia tutorials (outlined below) that you will work through asynchronously *before* the course begins at your own pace.
 
 What is Project Pythia? Check out the fantastic [~5min video](https://bit.ly/42P799Y) that Julia Kent prepared for you as an intro to this fabulous material.
 
-Below are the lessons you need to review. **To get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook and then clikc the 'launch in Binder' button that appears (see image below and more instructoins [here](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder))!** If you’re from a Matlab background, you may find reviewing [this cheatsheet](https://cheatsheets.quantecon.org/) helpful before you get started.
+Below are the lessons you need to review. **To get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook and then click the 'Binder' button that appears ro launch the tutorial (see image below and more instructoins [here](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder))!** If you’re from a Matlab background, you may find reviewing [this cheatsheet](https://cheatsheets.quantecon.org/) helpful before you get started.
 
 ![Launch Binder](../images/binder.png)
 
@@ -50,28 +50,28 @@ Below are the lessons you need to review. **To get started with a tutorial just 
 
 To ensure clarity and set proper expectations, let’s revisit what you can expect from the **Python pre-course** and what you should not expect.
 
-### What You Can Expect from the Python Pre-course
+### What You Can Expect from the Python Refresher
 
-- Self-Study Approach: The precourse is *not* designed as a traditional course with lectures and guided lessons. Instead, we have curated a collection of comprehensive learning materials for you to study independently.  It is essential that you dedicate sufficient time and effort to self-study the content at your own pace through the links provided above.
+- Self-Study Approach: The refresher is *not* designed as a traditional course with lectures and guided lessons. Instead, we have curated a collection of comprehensive learning materials for you to study independently.  It is essential that you dedicate sufficient time and effort to self-study the content at your own pace through the links provided above.
     
-- Prior Programming Experience Advantage: If you have prior experience in programming, you may find this pre-course relatively easy to grasp. 
+- Prior Programming Experience Advantage: If you have a large degree of prior experience in programming, you may find this refresher relatively easy to grasp. 
     
 - For those with less of a programming background, it is crucial to study the material well in advance. We recommend beginning as early as possible to ensure you have ample time to cover the content. Practice every day and you'll be in great shape before the course begins.
     
-- You won't need to install Python on your computer for the Python pre-course. All you need to do is click the rocket-shaped button in the upper right corner of the lessons and sign in using your Github account if needed. 
+- You won't need to install Python on your computer for the Python refresher. All you need to do is click the rocket-shaped button in the upper right corner of the lessons.
 
 - The section [“How to use this book”](https://foundations.projectpythia.org/preamble/how-to-use.html#how-to-use-this-book) provides you with alternative options to run the Python code should you need to.
 
 - If nothing works, please don’t panic. Sometimes depending on your region, your internet access, and your computer, some challenges may arise, but we will be happy to assist you. Please email  [nma@neuromatch.io](mailto:nma@neuromatch.io) if you need help.
     
 
-### What You Should Not Expect from the Python Pre-course
+### What You Should Not Expect from the Python Refresher
 
-- Guided Instruction: Please be aware that the Python pre-course does not include virtual online classes or guided instruction.  It is on you to study the material independently and seek clarification as needed from existing online resources.
+- Guided Instruction: Please be aware that the Python refresher does not include virtual online classes or guided instruction.  It is on you to study the material independently and seek clarification as needed from existing online resources.
 
-- Traditional Classroom Environment: Unlike traditional courses where you attend classes and follow a set schedule, the pre-course relies on your self-motivation and discipline to study the provided materials. There will not be any fixed class times or mandatory attendance.
+- Traditional Classroom Environment: Unlike traditional courses where you attend classes and follow a set schedule, the refresher relies on your self-motivation and discipline to study the provided materials. There will not be any fixed class times or mandatory attendance.
 
-- In-depth Coverage of Advanced Topics: The Python pre-course primarily focuses on introducing the fundamentals of Python programming. It does not delve into advanced topics. We recommend the [Software carpentry 1-day Python tutorial](https://swcarpentry.github.io/python-novice-inflammation/) or the free Edx course [Using Python for Research](https://www.edx.org/course/using-python-for-research). For a more in-depth intro, see the [scipy lecture notes](https://scipy-lectures.org/). Finally, you can follow the [Python data science handbook](https://jakevdp.github.io/PythonDataScienceHandbook/), which also has a print edition. 
+- In-depth Coverage of Advanced Topics: The Python refresher primarily focuses on introducing the fundamentals of Python programming. It does not delve into advanced topics. We recommend the [Software carpentry 1-day Python tutorial](https://swcarpentry.github.io/python-novice-inflammation/) or the free Edx course [Using Python for Research](https://www.edx.org/course/using-python-for-research). For a more in-depth intro, see the [scipy lecture notes](https://scipy-lectures.org/). Finally, you can follow the [Python data science handbook](https://jakevdp.github.io/PythonDataScienceHandbook/), which also has a print edition. 
 
     
 ## Math 

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -42,7 +42,7 @@ Below are the lessons you need to review. **To get started with a tutorial just 
 | [Overview](https://foundations.projectpythia.org/core/overview.html)  | 10 |
 | [NumPy](https://foundations.projectpythia.org/core/numpy.html) | 85  |
 | [Matplotlib](https://foundations.projectpythia.org/core/matplotlib.html) | 100 |
-| [Cartopy]([https://foundations.projectpythia.org/core/matplotlib.html](https://foundations.projectpythia.org/core/cartopy.html) | 30 |
+| [Cartopy](https://foundations.projectpythia.org/core/cartopy.html) | 30 |
 | [Datetime](https://foundations.projectpythia.org/core/datetime.html) | 30 |
 | [Pandas](https://foundations.projectpythia.org/core/pandas.html) | 60 |
 | [Data Formats](https://foundations.projectpythia.org/core/data-formats.html) | 50 |

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -35,14 +35,14 @@ Below are the lessons you need to review. **To get started with a tutorial just 
 | [Quickstart: Zero to Python](https://foundations.projectpythia.org/foundations/quickstart.html) | 90 |
 | [Jupyterlab](https://foundations.projectpythia.org/foundations/jupyterlab.html) | 50 |
     
-### [Core Scientific Python Packages](https://foundations.projectpythia.org/core/overview.html)(~6 hours).
+### [Core Scientific Python Packages](https://foundations.projectpythia.org/core/overview.html)(~6 hours)
     
 | Tutorial Section and Link | Approximate Time to Complete (minutes) |
 | ----------- | ----------- |
 | [Overview](https://foundations.projectpythia.org/core/overview.html)  | 10 |
 | [NumPy](https://foundations.projectpythia.org/core/numpy.html) | 85  |
 | [Matplotlib](https://foundations.projectpythia.org/core/matplotlib.html) | 100 |
-| [Cartopy]([https://foundations.projectpythia.org/core/matplotlib.html](https://foundations.projectpythia.org/core/cartopy.html)) | 30 |
+| [Cartopy]([https://foundations.projectpythia.org/core/matplotlib.html](https://foundations.projectpythia.org/core/cartopy.html) | 30 |
 | [Datetime](https://foundations.projectpythia.org/core/datetime.html) | 30 |
 | [Pandas](https://foundations.projectpythia.org/core/pandas.html) | 60 |
 | [Data Formats](https://foundations.projectpythia.org/core/data-formats.html) | 50 |

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -62,7 +62,7 @@ To ensure clarity and set proper expectations, let’s revisit what you can expe
 
 - The section [“How to use this book”](https://foundations.projectpythia.org/preamble/how-to-use.html#how-to-use-this-book) provides you with alternative options to run the Python code should you need to.
 
-- If nothing works, please don’t panic. Sometimes depending on your region, your internet access, and your computer, some challenges may arise, but we will be happy to assist you. Please email  [python_precourse@climatematch.io](mailto:python_precourse@climatematch.io) if you need help.
+- If nothing works, please don’t panic. Sometimes depending on your region, your internet access, and your computer, some challenges may arise, but we will be happy to assist you. Please email  [nma@neuromatch.io](mailto:nma@neuromatch.io) if you need help.
     
 
 ### What You Should Not Expect from the Python Pre-course

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -22,7 +22,7 @@ We expect students to be familiar with fundamental Python and data storage conce
 
 What is Project Pythia? Check out the fantastic [~5min video](https://bit.ly/42P799Y) that Julia Kent prepared for you as an intro to this fabulous material.
 
-Below are the lessons you need to review. **To get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook to launch in Binder (see image below and more instructoins [here](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder))!** If you’re from a Matlab background, you may find reviewing [this cheatsheet](https://cheatsheets.quantecon.org/) helpful before you get started.
+Below are the lessons you need to review. **To get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook and then clikc the 'launch in Binder' button that appears (see image below and more instructoins [here](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder))!** If you’re from a Matlab background, you may find reviewing [this cheatsheet](https://cheatsheets.quantecon.org/) helpful before you get started.
 
 ![Launch Binder](../images/binder.png)
 

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -22,7 +22,7 @@ We expect students to be familiar with fundamental Python and data storage conce
 
 What is Project Pythia? Check out the fantastic [~5min video](https://bit.ly/42P799Y) that Julia Kent prepared for you as an intro to this fabulous material.
 
-Below are the lessons you need to review. **To get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook to launch in Binder (see more instructoins [here](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder))!** If you’re from a Matlab background, you may find reviewing [this cheatsheet](https://cheatsheets.quantecon.org/) helpful before you get started.
+Below are the lessons you need to review. **To get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook to launch in Binder (see image below and more instructoins [here](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder))!** If you’re from a Matlab background, you may find reviewing [this cheatsheet](https://cheatsheets.quantecon.org/) helpful before you get started.
 
 ![Launch Binder](../images/binder.png)
 

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -69,7 +69,7 @@ To ensure clarity and set proper expectations, let’s revisit what you can expe
 - If nothing works, please don’t panic. Sometimes depending on your region, your internet access, and your computer, some challenges may arise, but we will be happy to assist you. Please email  [python_precourse@climatematch.io](mailto:python_precourse@climatematch.io) if you need help.
     
 
-### What You Should Not Expect from the Python Pre-course**
+### What You Should Not Expect from the Python Pre-course
 
 - Guided Instruction: Please be aware that the Python pre-course does not include virtual online classes or guided instruction. While our team will be available for support via ** CHECK Discord chat during July 12-14**, it is on you to study the material independently and seek clarification as needed.
 

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -1,6 +1,6 @@
 # Prerequisites and preparatory materials for Computational Tools for Climate Science
 
-Welcome to [Computational Tools for Climate Science](https://academy.climatematch.io/about/mission)! We are very excited to bring this course to such a wide and varied audience. We want to make sure every student is able to follow and enjoy the materials presented during the course. In order to get the most out of the materials we offer, we expect our students to know the basics of programming in Python, as well core concepts in math and science. Below 👇 we provide more details for each.
+Welcome to [Climatematch Academy](https://academy.climatematch.io/about/mission)! We are very excited to bring *Computational Tools for Climate Sceince* to such a wide and varied audience. We want to make sure every student is able to follow and enjoy the materials presented during the course. In order to get the most out of the materials we offer, we expect our students to know the basics of programming in Python, as well core concepts in math and science. Below 👇 we provide more details for each.
 
 ## Contents
 
@@ -22,7 +22,9 @@ We expect students to be familiar with fundamental Python and data storage conce
 
 What is Project Pythia? Check out the fantastic [~5min video](https://bit.ly/42P799Y) that Julia Kent prepared for you as an intro to this fabulous material.
 
-Below are the lessons you need to review, to get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook to launch the Binder
+Below are the lessons you need to review. **To get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook to launch in Binder (see more instructoins [here](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder))!** If you’re from a Matlab background, you may find reviewing [this cheatsheet](https://cheatsheets.quantecon.org/) helpful before you get started.
+
+![Launch Binder](../images/binder.png)
 
 ### [Preamble and Foundational Skills](https://bit.ly/4429kYQ) (~3 hours)
 
@@ -44,61 +46,38 @@ Below are the lessons you need to review, to get started with a tutorial just cl
 | [Datetime](https://foundations.projectpythia.org/core/datetime.html) | 30 |
 | [Pandas](https://foundations.projectpythia.org/core/pandas.html) | 60 |
 | [Data Formats](https://foundations.projectpythia.org/core/data-formats.html) | 50 |
-| Optional (will be covered on first day in course materials): [Xarray](https://foundations.projectpythia.org/core/xarray.html) | 150 |
+| Optional (will be covered in the first day of course materials): [Xarray](https://foundations.projectpythia.org/core/xarray.html) | 150 |
 
-<span style="color:red">You will work through the material at your own pace, getting asynchronous help on Discord as needed during July 12-14. </span>
+**You will work through the material at your own pace, getting asynchronous help on **Discord as needed during July 12-14. NEED TO CONFIRM THIS** 
 
 To ensure clarity and set proper expectations, let’s revisit what you can expect from the **Python pre-course** and what you should not expect.
 
-**What You Can Expect from the Python pre-course**
+### What You Can Expect from the Python Pre-course
 
-- Asynchronous Support via Discord: Throughout the duration of the precourse, (July 12-14), our team will provide support through the Discord platform. You will have the opportunity to ask questions and seek assistance via chat. Please note that we will not be conducting any video calls or virtual classes during the Python pre-course.
+- Asynchronous Support via Discord: ** CHECK THIS Throughout the duration of the precourse, (July 12-14)**, our team will provide support through the Discord platform. You will have the opportunity to ask questions and seek assistance via chat. Please note that we will not be conducting any video calls or virtual classes during the Python pre-course.
+
+- Self-Study Approach: The precourse is not designed as a traditional course with lectures and guided lessons. Instead, we have curated a collection of comprehensive learning materials for you to study independently. These materials are accessible through the links provided. It is essential that you dedicate sufficient time and effort to self-study the content at your own pace through the links provided above.
     
-
-  
-
-- Self-Study Approach: The precourse is not designed as a traditional course with lectures and guided lessons. Instead, we have curated a collection of comprehensive learning materials for you to study independently. These materials are accessible through the link provided. It is essential that you dedicate sufficient time and effort to self-study the content at your own pace.
+- Prior Programming Experience Advantage: If you have prior experience in programming, you may find this pre-course relatively easier to grasp. 
     
-- Prior Programming Experience Advantage: If you have prior experience in programming, you may find this precourse relatively easier to grasp. 
+ - For those without any previous programming background, it is crucial to start studying the material well in advance. We recommend beginning as early as possible to ensure you have ample time to cover the content. Practice every day and you'll be in great shape before the course begins.
     
+- You won't need to install Python on your computer for the Python pre-course. All you need to do is click the rocket-shaped button in the upper right corner of the lessons ** CHECK THIS TOO I DIDNT NEED TO SIGN IN and sign in using your Github account**. 
 
- - For those without any previous programming background, it is crucial to start studying the material well in advance. We recommend beginning as early as possible to ensure you have ample time to cover the content. Practice every day and you'll be in great shape before July 17th.
-    
-- You won't need to install Python on your computer for the Python pre-course. You literally just need to hit the rocket-shaped button in the upper right corner of the lessons (see image below) and sign in using your Github account. 
-![Launch Binder](../images/binder.png)
-
- 
-
-  
-
-- The section [“How to use this book”](https://foundations.projectpythia.org/preamble/how-to-use.html#how-to-use-this-book) provides you with alternative options to run the Python code.
+- The section [“How to use this book”](https://foundations.projectpythia.org/preamble/how-to-use.html#how-to-use-this-book) provides you with alternative options to run the Python code should you need to.
 
 - If nothing works, please don’t panic. Sometimes depending on your region, your internet access, and your computer, some challenges may arise, but we will be happy to assist you. Please email  [python_precourse@climatematch.io](mailto:python_precourse@climatematch.io) if you need help.
     
 
-**What You Should Not Expect  from the Python pre-course**
+### What You Should Not Expect from the Python Pre-course**
 
-- Guided Instruction: Please be aware that the Python precourse does not include virtual online classes or guided instruction. While our team will be available for support via Discord chat during July 12-14, the onus is on you to study the material independently and seek clarification as needed.
+- Guided Instruction: Please be aware that the Python pre-course does not include virtual online classes or guided instruction. While our team will be available for support via ** CHECK Discord chat during July 12-14**, it is on you to study the material independently and seek clarification as needed.
+
+- Traditional Classroom Environment: Unlike traditional courses where you attend classes and follow a set schedule, the pre-course relies on your self-motivation and discipline to study the provided materials. There will not be any fixed class times or mandatory attendance.
+
+- In-depth Coverage of Advanced Topics: The Python pre-course primarily focuses on introducing the fundamentals of Python programming. It does not delve into advanced topics. We recommend the [Software carpentry 1-day Python tutorial](https://swcarpentry.github.io/python-novice-inflammation/) or the free Edx course [Using Python for Research](https://www.edx.org/course/using-python-for-research). For a more in-depth intro, see the [scipy lecture notes](https://scipy-lectures.org/). Finally, you can follow the [Python data science handbook](https://jakevdp.github.io/PythonDataScienceHandbook/), which also has a print edition. 
+
     
-
-  
-
-- Traditional Classroom Environment: Unlike traditional courses where you attend classes and follow a set schedule, the precourse relies on your self-motivation and discipline to study the provided materials. There will not be any fixed class times or mandatory attendance.
-    
-
-  
-
-- In-depth Coverage of Advanced Topics: The Python pre-course primarily focuses on introducing the fundamentals of Python programming. It does not delve into advanced topics.
-    
-
-  
-
->Extra material
->
->We recommend the [Software carpentry 1-day Python tutorial](https://swcarpentry.github.io/python-novice-inflammation/) or the free Edx course [Using Python for Research](https://www.edx.org/course/using-python-for-research). For a more in-depth intro, see the [scipy lecture notes](https://scipy-lectures.org/). Finally, you can follow the [Python data science handbook](https://jakevdp.github.io/PythonDataScienceHandbook/), which also has a print edition. 
-If you're coming from a Matlab background, you can quickly get up to speed with [this cheatsheet](https://cheatsheets.quantecon.org/). 
-
-
 ## Math 
 
   

--- a/prereqs/ClimateScience.md
+++ b/prereqs/ClimateScience.md
@@ -18,28 +18,37 @@ Welcome to [Computational Tools for Climate Science](https://academy.climatematc
 ## Programming
 
 
-We expect students to be familiar with fundamental Python and data storage concepts (variables, lists, dictionaries, data formats) as well as some key Python libraries (numpy, matplotlib, cartopy, datetime, pandas, XArray).  If these feel unfamiliar, we **highly recommend** you take our refresher **Python pre-course**. It is a selection of Project Pythia tutorials (outlined below) that you will work through asynchronously *before* the course begins. 
+We expect students to be familiar with fundamental Python and data storage concepts (variables, lists, dictionaries, data formats) as well as some key Python libraries (NumPy, matplotlib, cartopy, datetime, pandas, XArray).  If these feel unfamiliar, we **highly recommend** you take our refresher **Python pre-course**. It is a selection of Project Pythia tutorials (outlined below) that you will work through asynchronously *before* the course begins. 
 
 What is Project Pythia? Check out the fantastic [~5min video](https://bit.ly/42P799Y) that Julia Kent prepared for you as an intro to this fabulous material.
 
 Below are the lessons you need to review, to get started with a tutorial just click on the on the rocket icon at the top right of each tutorial notebook to launch the Binder
 
-- [Preamble and Foundational Skills](https://bit.ly/4429kYQ):
+### [Preamble and Foundational Skills](https://bit.ly/4429kYQ) (~3 hours)
 
-| Tutorial and Link | Approximate Time to Complete (minutes) |
+| Tutorial Section and Link | Approximate Time to Complete (minutes) |
 | ----------- | ----------- |
 | [Interacting with Jupyter Notebooks in the cloud via Binder](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder)  | 10 |
 | [Why Python?](https://foundations.projectpythia.org/foundations/why-python.html) | 15  |
 | [Quickstart: Zero to Python](https://foundations.projectpythia.org/foundations/quickstart.html) | 90 |
-
-- Why Python? and  Quickstart: Zero to Python (under the heading “Getting Started with Python”) tutorials (~2 hours)
+| [Jupyterlab](https://foundations.projectpythia.org/foundations/jupyterlab.html) | 50 |
     
-- Core Scientific Python Packages: all tutorials (~6 hours).
+### [Core Scientific Python Packages](https://foundations.projectpythia.org/core/overview.html)(~6 hours).
     
+| Tutorial Section and Link | Approximate Time to Complete (minutes) |
+| ----------- | ----------- |
+| [Overview](https://foundations.projectpythia.org/core/overview.html)  | 10 |
+| [NumPy](https://foundations.projectpythia.org/core/numpy.html) | 85  |
+| [Matplotlib](https://foundations.projectpythia.org/core/matplotlib.html) | 100 |
+| [Cartopy]([https://foundations.projectpythia.org/core/matplotlib.html](https://foundations.projectpythia.org/core/cartopy.html)) | 30 |
+| [Datetime](https://foundations.projectpythia.org/core/datetime.html) | 30 |
+| [Pandas](https://foundations.projectpythia.org/core/pandas.html) | 60 |
+| [Data Formats](https://foundations.projectpythia.org/core/data-formats.html) | 50 |
+| Optional (will be covered on first day in course materials): [Xarray](https://foundations.projectpythia.org/core/xarray.html) | 150 |
 
-  
+<span style="color:red">You will work through the material at your own pace, getting asynchronous help on Discord as needed during July 12-14. </span>
 
-You will work through the material at your own pace, getting asynchronous help on Discord as needed during July 12-14. To ensure clarity and set proper expectations, let’s revisit what you can expect from the **Python pre-course** and what you should not expect.
+To ensure clarity and set proper expectations, let’s revisit what you can expect from the **Python pre-course** and what you should not expect.
 
 **What You Can Expect from the Python pre-course**
 


### PR DESCRIPTION
2024 updates to pre-reqs. Big changes are removing the python advisors, the dates, and reframing to a refresher instead of pre-course for python. Also added a table directly into the markdown file instead of linking to the google sheet.